### PR TITLE
Add Dalamud toast and notification alerts

### DIFF
--- a/AdventurerInNeed.cs
+++ b/AdventurerInNeed.cs
@@ -155,9 +155,27 @@ namespace AdventurerInNeed {
             }
 
             if (PluginConfig.ToastAlert) {
-                ToastGui.ShowQuest(
-                    $"{roulette.Name.ExtractText()} needs a {role}!",
-                    new QuestToastOptions());
+                uint roleIconId = role switch {
+                    ContentsRouletteRole.Tank   => 62581u,
+                    ContentsRouletteRole.Healer => 62582u,
+                    ContentsRouletteRole.Dps    => 62583u,
+                    _                           => 0u,
+                };
+
+                var toastIcon = role switch {
+                    ContentsRouletteRole.Tank   => BitmapFontIcon.Tank,
+                    ContentsRouletteRole.Healer => BitmapFontIcon.Healer,
+                    ContentsRouletteRole.Dps    => BitmapFontIcon.DPS,
+                    _                           => BitmapFontIcon.Warning,
+                };
+
+                var toastMessage = new SeString(new Payload[] {
+                    new TextPayload($"{roulette.Name.ExtractText()} needs a "),
+                    new IconPayload(toastIcon),
+                    new TextPayload($"{role}!"),
+                });
+
+                ToastGui.ShowQuest(toastMessage, new QuestToastOptions { IconId = roleIconId });
             }
 
             if (PluginConfig.WindowsAlert) {

--- a/AdventurerInNeed.cs
+++ b/AdventurerInNeed.cs
@@ -4,9 +4,11 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Timers;
+using Dalamud.Game.Gui.Toast;
 using Dalamud.Game.Text;
 using Dalamud.Game.Text.SeStringHandling;
 using Dalamud.Game.Text.SeStringHandling.Payloads;
+using Dalamud.Interface.ImGuiNotification;
 using Dalamud.Interface.Windowing;
 using Dalamud.IoC;
 using Dalamud.Plugin;
@@ -30,6 +32,8 @@ namespace AdventurerInNeed {
         [PluginService] public static IChatGui ChatGui { get; private set; } = null!;
         [PluginService] public static ICommandManager CommandManager { get; private set; } = null!;
         [PluginService] public static IPluginLog PluginLog { get; private set; } = null!;
+        [PluginService] public static IToastGui ToastGui { get; private set; } = null!;
+        [PluginService] public static INotificationManager NotificationManager { get; private set; } = null!;
 
 
         private IClientState _clientState;
@@ -148,6 +152,20 @@ namespace AdventurerInNeed {
                 }
 
                 ChatGui.Print(xivChat);
+            }
+
+            if (PluginConfig.ToastAlert) {
+                ToastGui.ShowQuest(
+                    $"{roulette.Name.ExtractText()} needs a {role}!",
+                    new QuestToastOptions());
+            }
+
+            if (PluginConfig.WindowsAlert) {
+                NotificationManager.AddNotification(new Notification {
+                    Title = "Adventurer in Need",
+                    Content = $"{roulette.Name.ExtractText()} needs a {role}!",
+                    Type = NotificationType.Info,
+                });
             }
         }
 

--- a/AdventurerInNeedConfig.cs
+++ b/AdventurerInNeedConfig.cs
@@ -23,6 +23,8 @@ namespace AdventurerInNeed {
         public Dictionary<uint, RouletteConfig> Roulettes { get; set; } = new();
         public int Version { get; set; }
         public bool InGameAlert { get; set; }
+        public bool ToastAlert { get; set; } = false;
+        public bool WindowsAlert { get; set; } = false;
         public XivChatType ChatType { get; set; } = XivChatType.SystemMessage;
     }
 }

--- a/ConfigWindow.cs
+++ b/ConfigWindow.cs
@@ -77,6 +77,22 @@ public class ConfigWindow(AdventurerInNeed plugin, IDalamudPluginInterface plugi
                 ImGui.EndCombo();
             }
 
+            var toastAlert = Config.ToastAlert;
+            if (ImGui.Checkbox("Show Dalamud toast notification.", ref toastAlert)) {
+                Config.ToastAlert = toastAlert;
+                modified = true;
+            }
+            if (ImGui.IsItemHovered())
+                ImGui.SetTooltip("Shows a quest-style HUD toast when a role bonus changes.");
+
+            var windowsAlert = Config.WindowsAlert;
+            if (ImGui.Checkbox("Show Dalamud notification.", ref windowsAlert)) {
+                Config.WindowsAlert = windowsAlert;
+                modified = true;
+            }
+            if (ImGui.IsItemHovered())
+                ImGui.SetTooltip("Shows a Dalamud notification card when a role bonus changes.");
+
             ImGui.Separator();
             ImGui.Columns(7, "###cols", false);
             ImGui.SetColumnWidth(0, 60f * scale);
@@ -122,7 +138,7 @@ public class ConfigWindow(AdventurerInNeed plugin, IDalamudPluginInterface plugi
                     }
 
 
-                    var e = rCfg.Enabled && (rCfg.Tank || rCfg.Healer || rCfg.DPS) && (Config.InGameAlert);
+                    var e = rCfg.Enabled && (rCfg.Tank || rCfg.Healer || rCfg.DPS) && (Config.InGameAlert || Config.ToastAlert || Config.WindowsAlert);
                     
                     using var textColor = ImRaii.PushColor(ImGuiCol.Text, ImGuiColors.DalamudGrey3, !e);
                     using var checkMarkColor = ImRaii.PushColor(ImGuiCol.CheckMark, ImGuiColors.DalamudGrey3, !e);


### PR DESCRIPTION
Really big fan of this plugin but I don't really pay attention to my chat log all that much. This uses the Dalmud API to create Toast popups/alerts so it's easier to see when your selected role(s) are ready. 